### PR TITLE
Upgrade to v5.19.3.9730

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It shall NOT be edited by hand.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Shipped version:** 5.18.4.9674~ynh1
+**Shipped version:** 5.19.3.9730~ynh1
 
 ## Screenshots
 

--- a/README_es.md
+++ b/README_es.md
@@ -20,7 +20,7 @@ No se debe editar a mano.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Versión actual:** 5.18.4.9674~ynh1
+**Versión actual:** 5.19.3.9730~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -20,7 +20,7 @@ EZ editatu eskuz.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Paketatutako bertsioa:** 5.18.4.9674~ynh1
+**Paketatutako bertsioa:** 5.19.3.9730~ynh1
 
 ## Pantaila-argazkiak
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Il NE doit PAS être modifié à la main.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Version incluse :** 5.18.4.9674~ynh1
+**Version incluse :** 5.19.3.9730~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -20,7 +20,7 @@ NON debe editarse manualmente.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Versión proporcionada:** 5.18.4.9674~ynh1
+**Versión proporcionada:** 5.19.3.9730~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -20,7 +20,7 @@ Ini TIDAK boleh diedit dengan tangan.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Versi terkirim:** 5.18.4.9674~ynh1
+**Versi terkirim:** 5.19.3.9730~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -20,7 +20,7 @@ Hij mag NIET handmatig aangepast worden.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Geleverde versie:** 5.18.4.9674~ynh1
+**Geleverde versie:** 5.19.3.9730~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -20,7 +20,7 @@ Nie powinno być ono edytowane ręcznie.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Dostarczona wersja:** 5.18.4.9674~ynh1
+**Dostarczona wersja:** 5.19.3.9730~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -20,7 +20,7 @@
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Поставляемая версия:** 5.18.4.9674~ynh1
+**Поставляемая версия:** 5.19.3.9730~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -20,7 +20,7 @@
 
 Movie collection manager for Usenet and BitTorrent users
 
-**分发版本：** 5.18.4.9674~ynh1
+**分发版本：** 5.19.3.9730~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -1,3 +1,5 @@
+#:schema https://raw.githubusercontent.com/YunoHost/apps/master/schemas/manifest.v2.schema.json
+
 packaging_format = 2
 
 id = "radarr"
@@ -5,7 +7,7 @@ name = "Radarr"
 description.en = "Movie collection manager for Usenet and BitTorrent users"
 description.fr = "Gestionnaire de filmothèque pour utilisateurs de Usenet et BitTorrent"
 
-version = "5.18.4.9674~ynh1"
+version = "5.19.3.9730~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -41,22 +43,20 @@ ram.runtime = "100M"
 
 [resources]
     [resources.sources.main]
-    armhf.url = "https://github.com/Radarr/Radarr/releases/download/v5.18.4.9674/Radarr.master.5.18.4.9674.linux-core-arm.tar.gz"
-    armhf.sha256 = "d9e90af0fafd054ddc75025c5f329b64ba0253c017ac4d1f8747b7dd7f2d6287"
-    arm64.url = "https://github.com/Radarr/Radarr/releases/download/v5.18.4.9674/Radarr.master.5.18.4.9674.linux-core-arm64.tar.gz"
-    arm64.sha256 = "71640e75db4042a32fbd647cb853acff0d2256709283cfe736d62ea14704a807"
-    amd64.url = "https://github.com/Radarr/Radarr/releases/download/v5.18.4.9674/Radarr.master.5.18.4.9674.linux-core-x64.tar.gz"
-    amd64.sha256 = "0f4369f49cfb138ff57675a415d1d0206b6192509573ac9abf600013da4572ed"
-    i386.url = "https://github.com/Radarr/Radarr/releases/download/v5.18.4.9674/Radarr.master.5.18.4.9674.linux-core-x86.tar.gz"
-    i386.sha256 = "502f55cc9f8ccd189ae64ebe70063a02de24f606618e957b55d84b76578fe22d"
+    armhf.url = "https://github.com/Radarr/Radarr/releases/download/v5.19.3.9730/Radarr.master.5.19.3.9730.linux-core-arm.tar.gz"
+    armhf.sha256 = "8c4f66c8b24fad7df3102f60b25040ae866a53fd4310e8ff49f5035e06d1dfc5"
+    arm64.url = "https://github.com/Radarr/Radarr/releases/download/v5.19.3.9730/Radarr.master.5.19.3.9730.linux-core-arm64.tar.gz"
+    arm64.sha256 = "e0982d1e636826ff73511745cd141a3b4a20d3b1e96d554e9017fe8d58ae33b1"
+    amd64.url = "https://github.com/Radarr/Radarr/releases/download/v5.19.3.9730/Radarr.master.5.19.3.9730.linux-core-x64.tar.gz"
+    amd64.sha256 = "fcd568b0fc79e6499b894ac4c2a9424c547d7f207971b29a15902969f3c340be"
+    i386.url = "https://github.com/Radarr/Radarr/releases/download/v5.19.3.9730/Radarr.master.5.19.3.9730.linux-core-x86.tar.gz"
+    i386.sha256 = "050ff30d442ef8ef15599d39168a094aa1e9f319a6e4827e8bde7f56b8f30dfb"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.armhf = ".*linux-core-arm.tar.gz"
     autoupdate.asset.arm64 = ".*linux-core-arm64.tar.gz"
     autoupdate.asset.amd64 = ".*linux-core-x64.tar.gz"
     autoupdate.asset.i386 = ".*linux-core-x86.tar.gz"
-
-    [resources.ports]
 
     [resources.system_user]
 
@@ -71,6 +71,8 @@ ram.runtime = "100M"
     api.allowed = "visitors"
     api.show_tile = false
     api.protected = true
+
+    [resources.ports]
 
     [resources.apt]
     packages = "curl, mediainfo, sqlite3"

--- a/tests.toml
+++ b/tests.toml
@@ -1,6 +1,16 @@
+#:schema https://raw.githubusercontent.com/YunoHost/apps/master/schemas/tests.v1.schema.json
+
 test_format = 1.0
 
 [default]
+
+    # ------------
+    # Tests to run
+    # ------------
+
+    # -------------------------------
+    # Default args to use for install
+    # -------------------------------
 
     # -------------------------------
     # Commits to test upgrade from
@@ -10,3 +20,5 @@ test_format = 1.0
     test_upgrade_from.4db47c2.args.domain = "sub.domain.tld"
     test_upgrade_from.4db47c2.args.path = "/radarr"
     test_upgrade_from.4db47c2.args.admin = "package_checker"
+
+    test_upgrade_from.bfacb2f5b9a3847ee0c3d2e13c59ab88425f8aca.name = "Upgrade from 5.18.4.9674~ynh1"


### PR DESCRIPTION
Upgrade sources
- `main` v5.19.3.9730: https://github.com/Radarr/Radarr/releases/tag/v5.19.3.9730

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
