### PR TITLE
Upgrade to v5.21.1.9799

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -1,6 +1,8 @@
 # All available README files by language
 
 - [Read the README in English](README.md)
+- [Llegir el README en català](README_ca.md)
+- [Die README in Deutsch lesen](README_de.md)
 - [Lea el README en español](README_es.md)
 - [Irakurri README euskaraz](README_eu.md)
 - [Lire le README en français](README_fr.md)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It shall NOT be edited by hand.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Shipped version:** 5.20.2.9777~ynh1
+**Shipped version:** 5.21.1.9799~ynh1
 
 ## Screenshots
 

--- a/README_ca.md
+++ b/README_ca.md
@@ -1,0 +1,49 @@
+<!--
+N.B.: Aquest README ha estat generat automàticament per <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+NO s'ha de modificar manualment.
+-->
+
+# Radarr per YunoHost
+
+[![Nivell d'integració](https://apps.yunohost.org/badge/integration/radarr)](https://ci-apps.yunohost.org/ci/apps/radarr/)
+![Estat de funcionament](https://apps.yunohost.org/badge/state/radarr)
+![Estat de manteniment](https://apps.yunohost.org/badge/maintained/radarr)
+
+[![Instal·la Radarr amb YunoHosth](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=radarr)
+
+*[Llegeix aquest README en altres idiomes.](./ALL_README.md)*
+
+> *Aquest paquet et permet instal·lar Radarr de forma ràpida i senzilla en un servidor YunoHost.*  
+> *Si no tens YunoHost, consulta [la guia](https://yunohost.org/install) per saber com instal·lar-lo.*
+
+## Visió general
+
+Movie collection manager for Usenet and BitTorrent users
+
+**Versió inclosa:** 5.21.1.9799~ynh1
+
+## Captures de pantalla
+
+![Captures de pantalla de Radarr](./doc/screenshots/screenshot.jpg)
+
+## Documentació i recursos
+
+- Lloc web oficial de l'aplicació: <https://radarr.video>
+- Documentació oficial per l'administrador: <https://wiki.servarr.com/Radarr>
+- Repositori oficial del codi de l'aplicació: <https://github.com/Radarr/Radarr>
+- Botiga YunoHost: <https://apps.yunohost.org/app/radarr>
+- Reportar un error: <https://github.com/YunoHost-Apps/radarr_ynh/issues>
+
+## Informació per a desenvolupadors
+
+Envieu les pull request a la [branca `testing`](https://github.com/YunoHost-Apps/radarr_ynh/tree/testing).
+
+Per provar la branca `testing`, procedir com descrit a continuació:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/radarr_ynh/tree/testing --debug
+o
+sudo yunohost app upgrade radarr -u https://github.com/YunoHost-Apps/radarr_ynh/tree/testing --debug
+```
+
+**Més informació sobre l'empaquetatge d'aplicacions:** <https://yunohost.org/packaging_apps>

--- a/README_de.md
+++ b/README_de.md
@@ -1,0 +1,49 @@
+<!--
+N.B.: Diese README wurde automatisch von <https://github.com/YunoHost/apps/tree/master/tools/readme_generator> generiert.
+Sie darf NICHT von Hand bearbeitet werden.
+-->
+
+# Radarr für YunoHost
+
+[![Integrations-Level](https://apps.yunohost.org/badge/integration/radarr)](https://ci-apps.yunohost.org/ci/apps/radarr/)
+![Funktionsstatus](https://apps.yunohost.org/badge/state/radarr)
+![Wartungsstatus](https://apps.yunohost.org/badge/maintained/radarr)
+
+[![Radarr mit YunoHost installieren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=radarr)
+
+*[Dieses README in anderen Sprachen lesen.](./ALL_README.md)*
+
+> *Mit diesem Paket können Sie Radarr schnell und einfach auf einem YunoHost-Server installieren.*  
+> *Wenn Sie YunoHost nicht haben, lesen Sie bitte [die Anleitung](https://yunohost.org/install), um zu erfahren, wie Sie es installieren.*
+
+## Übersicht
+
+Movie collection manager for Usenet and BitTorrent users
+
+**Ausgelieferte Version:** 5.21.1.9799~ynh1
+
+## Bildschirmfotos
+
+![Bildschirmfotos von Radarr](./doc/screenshots/screenshot.jpg)
+
+## Dokumentation und Ressourcen
+
+- Offizielle Website der App: <https://radarr.video>
+- Offizielle Verwaltungsdokumentation: <https://wiki.servarr.com/Radarr>
+- Upstream App Repository: <https://github.com/Radarr/Radarr>
+- YunoHost-Shop: <https://apps.yunohost.org/app/radarr>
+- Einen Fehler melden: <https://github.com/YunoHost-Apps/radarr_ynh/issues>
+
+## Entwicklerinformationen
+
+Bitte senden Sie Ihren Pull-Request an den [`testing` branch](https://github.com/YunoHost-Apps/radarr_ynh/tree/testing).
+
+Um den `testing` Branch auszuprobieren, gehen Sie bitte wie folgt vor:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/radarr_ynh/tree/testing --debug
+oder
+sudo yunohost app upgrade radarr -u https://github.com/YunoHost-Apps/radarr_ynh/tree/testing --debug
+```
+
+**Weitere Informationen zur App-Paketierung:** <https://yunohost.org/packaging_apps>

--- a/README_es.md
+++ b/README_es.md
@@ -3,7 +3,7 @@ Este archivo README esta generado automaticamente<https://github.com/YunoHost/ap
 No se debe editar a mano.
 -->
 
-# Radarr para Yunohost
+# Radarr para YunoHost
 
 [![Nivel de integración](https://apps.yunohost.org/badge/integration/radarr)](https://ci-apps.yunohost.org/ci/apps/radarr/)
 ![Estado funcional](https://apps.yunohost.org/badge/state/radarr)
@@ -20,7 +20,7 @@ No se debe editar a mano.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Versión actual:** 5.20.2.9777~ynh1
+**Versión actual:** 5.21.1.9799~ynh1
 
 ## Capturas
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -20,7 +20,7 @@ EZ editatu eskuz.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Paketatutako bertsioa:** 5.20.2.9777~ynh1
+**Paketatutako bertsioa:** 5.21.1.9799~ynh1
 
 ## Pantaila-argazkiak
 
@@ -38,7 +38,7 @@ Movie collection manager for Usenet and BitTorrent users
 
 Bidali `pull request`a [`testing` abarrera](https://github.com/YunoHost-Apps/radarr_ynh/tree/testing).
 
-`testing` abarra probatzeko, ondorengoa egin:
+`testing` abarra probatzeko, honakoa egin:
 
 ```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/radarr_ynh/tree/testing --debug

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Il NE doit PAS être modifié à la main.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Version incluse :** 5.20.2.9777~ynh1
+**Version incluse :** 5.21.1.9799~ynh1
 
 ## Captures d’écran
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -20,7 +20,7 @@ NON debe editarse manualmente.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Versión proporcionada:** 5.20.2.9777~ynh1
+**Versión proporcionada:** 5.21.1.9799~ynh1
 
 ## Capturas de pantalla
 

--- a/README_id.md
+++ b/README_id.md
@@ -20,7 +20,7 @@ Ini TIDAK boleh diedit dengan tangan.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Versi terkirim:** 5.20.2.9777~ynh1
+**Versi terkirim:** 5.21.1.9799~ynh1
 
 ## Tangkapan Layar
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -20,7 +20,7 @@ Hij mag NIET handmatig aangepast worden.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Geleverde versie:** 5.20.2.9777~ynh1
+**Geleverde versie:** 5.21.1.9799~ynh1
 
 ## Schermafdrukken
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -20,7 +20,7 @@ Nie powinno być ono edytowane ręcznie.
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Dostarczona wersja:** 5.20.2.9777~ynh1
+**Dostarczona wersja:** 5.21.1.9799~ynh1
 
 ## Zrzuty ekranu
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -20,7 +20,7 @@
 
 Movie collection manager for Usenet and BitTorrent users
 
-**Поставляемая версия:** 5.20.2.9777~ynh1
+**Поставляемая версия:** 5.21.1.9799~ynh1
 
 ## Снимки экрана
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -20,7 +20,7 @@
 
 Movie collection manager for Usenet and BitTorrent users
 
-**分发版本：** 5.20.2.9777~ynh1
+**分发版本：** 5.21.1.9799~ynh1
 
 ## 截图
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Radarr"
 description.en = "Movie collection manager for Usenet and BitTorrent users"
 description.fr = "Gestionnaire de filmothèque pour utilisateurs de Usenet et BitTorrent"
 
-version = "5.20.2.9777~ynh1"
+version = "5.21.1.9799~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -43,14 +43,14 @@ ram.runtime = "100M"
 
 [resources]
     [resources.sources.main]
-    armhf.url = "https://github.com/Radarr/Radarr/releases/download/v5.20.2.9777/Radarr.master.5.20.2.9777.linux-core-arm.tar.gz"
-    armhf.sha256 = "2fa9e9499eb623779a176dd2a03510bfd80f0608ffc518965f7756148b309769"
-    arm64.url = "https://github.com/Radarr/Radarr/releases/download/v5.20.2.9777/Radarr.master.5.20.2.9777.linux-core-arm64.tar.gz"
-    arm64.sha256 = "21565f3aaa66c2e30d2fb8b8db5fd0a11693f711f1819c34684f3046d1424830"
-    amd64.url = "https://github.com/Radarr/Radarr/releases/download/v5.20.2.9777/Radarr.master.5.20.2.9777.linux-core-x64.tar.gz"
-    amd64.sha256 = "f0af1bdcfeb6e66e51d733bf87c4febe5861998441e1ab2624e2f83ea6c9e444"
-    i386.url = "https://github.com/Radarr/Radarr/releases/download/v5.20.2.9777/Radarr.master.5.20.2.9777.linux-core-x86.tar.gz"
-    i386.sha256 = "d1b73e0dfac64cbb89ad111a33dbbf811db3090fe7841550f1db7a2605e22cd6"
+    armhf.url = "https://github.com/Radarr/Radarr/releases/download/v5.21.1.9799/Radarr.master.5.21.1.9799.linux-core-arm.tar.gz"
+    armhf.sha256 = "326a6110e941b9004077c41d842363803ac42de48b858cf68528daa3d4bc6624"
+    arm64.url = "https://github.com/Radarr/Radarr/releases/download/v5.21.1.9799/Radarr.master.5.21.1.9799.linux-core-arm64.tar.gz"
+    arm64.sha256 = "546d688b2611cdf78ba33da66c36d3136f4c2af3ed8efad928035bd47c35545c"
+    amd64.url = "https://github.com/Radarr/Radarr/releases/download/v5.21.1.9799/Radarr.master.5.21.1.9799.linux-core-x64.tar.gz"
+    amd64.sha256 = "fc478541d8643e479bc9a13630ba55a75ffdac7884a550d6056897d87f31c838"
+    i386.url = "https://github.com/Radarr/Radarr/releases/download/v5.21.1.9799/Radarr.master.5.21.1.9799.linux-core-x86.tar.gz"
+    i386.sha256 = "be661f489767b244bc88a78028e66db968689c569436be0b76c9f4c5faebc4cb"
 
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset.armhf = ".*linux-core-arm.tar.gz"


### PR DESCRIPTION
Upgrade sources
- `main` v5.21.1.9799: https://github.com/Radarr/Radarr/releases/tag/v5.21.1.9799

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
